### PR TITLE
Update patient urls & draft darwin servlet

### DIFF
--- a/core/src/main/java/org/mskcc/cbio/portal/servlet/CheckDarwinAccessServlet.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/servlet/CheckDarwinAccessServlet.java
@@ -30,23 +30,30 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-package org.mskcc.cbio.portal.util;
+package org.mskcc.cbio.portal.servlet;
 
-import org.mskcc.cbio.portal.servlet.PatientView;
+import org.mskcc.cbio.portal.util.SpringUtil;
+import org.mskcc.cbio.portal.util.GlobalProperties;
+import org.apache.log4j.Logger;
 
 import org.springframework.http.*;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.context.support.SpringBeanAutowiringSupport;
 
 import org.apache.commons.cli.*;
 import org.apache.commons.lang.builder.ToStringBuilder;
 
+import java.io.*;
 import java.util.*;
 import javax.annotation.Generated;
 import com.fasterxml.jackson.annotation.*;
 import java.util.regex.Pattern;
 
-import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.*;
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
 
 /**
  *
@@ -59,7 +66,15 @@ import javax.servlet.http.HttpServletRequest;
 "p_userName",
 "p_dmp_pid"
 })
-public class CheckDarwinAccessMain {
+public class CheckDarwinAccessServlet extends HttpServlet {
+    private static Logger logger = Logger.getLogger(CheckDarwinAccessServlet.class);
+
+    @Override
+    public void init(ServletConfig config) throws ServletException {
+        super.init(config);
+        SpringBeanAutowiringSupport.processInjectionBasedOnServletContext(this,
+                config.getServletContext());
+    }
     
     public static class CheckDarwinAccess {
         private static String darwinAuthUrl = GlobalProperties.getDarwinAuthCheckUrl();
@@ -81,7 +96,7 @@ public class CheckDarwinAccessMain {
             }
             catch (NullPointerException ex) {}
             
-            return darwinResponse;
+			return darwinResponse;
         }
         
         public static String getResponse(String userName, String patientId){
@@ -253,25 +268,82 @@ public class CheckDarwinAccessMain {
         System.exit(exitStatus);
     }    
 
-    public static void main(String[] args) throws Exception {
-        Options gnuOptions = CheckDarwinAccessMain.getOptions(args);
-        CommandLineParser parser = new DefaultParser();
-        CommandLine commandLine = parser.parse(gnuOptions, args);
-        if (commandLine.hasOption("h") ||
-            !commandLine.hasOption("user_name") ||
-            !commandLine.hasOption("patient_id") || 
-            !commandLine.hasOption("sample_id")) {
-            help(gnuOptions, 0);
-        }
-        if (!CheckDarwinAccess.sampleIdRegex.matcher(commandLine.getOptionValue("sample_id")).find()) {
-            System.out.println("Sample ID doesn't match pattern");
-        }
-        else {
-            System.out.println("Sample ID valid - checking if user has access");
-            String darwinAccessUrl = CheckDarwinAccess.getResponse( 
-                commandLine.getOptionValue("user_name").split("@")[0],
-                commandLine.getOptionValue("patient_id"));
-            System.out.println(!darwinAccessUrl.isEmpty()?darwinAccessUrl:"Invalid request!");
-        }
+   // public static void main(String[] args) throws Exception {
+   //     Options gnuOptions = CheckDarwinAccessMain.getOptions(args);
+   //     CommandLineParser parser = new DefaultParser();
+   //     CommandLine commandLine = parser.parse(gnuOptions, args);
+   //     if (commandLine.hasOption("h") ||
+   //         !commandLine.hasOption("user_name") ||
+   //         !commandLine.hasOption("patient_id") || 
+   //         !commandLine.hasOption("sample_id")) {
+   //         help(gnuOptions, 0);
+   //     }
+   //     if (!CheckDarwinAccess.sampleIdRegex.matcher(commandLine.getOptionValue("sample_id")).find()) {
+   //         System.out.println("Sample ID doesn't match pattern");
+   //     }
+   //     else {
+   //         System.out.println("Sample ID valid - checking if user has access");
+   //         String darwinAccessUrl = CheckDarwinAccess.getResponse( 
+   //             commandLine.getOptionValue("user_name").split("@")[0],
+   //             commandLine.getOptionValue("patient_id"));
+   //         System.out.println(!darwinAccessUrl.isEmpty()?darwinAccessUrl:"Invalid request!");
+   //     }
+   // }
+
+    /** 
+     * Processes requests for both HTTP <code>GET</code> and <code>POST</code> methods.
+     * @param request servlet request
+     * @param response servlet response
+     * @throws ServletException if a servlet-specific error occurs
+     * @throws IOException if an I/O error occurs
+     */
+    protected void processRequest(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+
+		String darwinResponse = CheckDarwinAccess.checkAccess(request);
+
+		response.setContentType("text/plain");
+		PrintWriter out = response.getWriter();
+		try {
+			out.write(darwinResponse);
+		} finally {            
+			out.close();
+		}
     }
+
+    // <editor-fold defaultstate="collapsed" desc="HttpServlet methods. Click on the + sign on the left to edit the code.">
+    /** 
+     * Handles the HTTP <code>GET</code> method.
+     * @param request servlet request
+     * @param response servlet response
+     * @throws ServletException if a servlet-specific error occurs
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        processRequest(request, response);
+    }
+
+    /** 
+     * Handles the HTTP <code>POST</code> method.
+     * @param request servlet request
+     * @param response servlet response
+     * @throws ServletException if a servlet-specific error occurs
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        processRequest(request, response);
+    }
+
+    /** 
+     * Returns a short description of the servlet.
+     * @return a String containing servlet description
+     */
+    @Override
+    public String getServletInfo() {
+        return "Short description";
+    }// </editor-fold>
 }

--- a/core/src/main/java/org/mskcc/cbio/portal/servlet/PatientView.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/servlet/PatientView.java
@@ -33,44 +33,17 @@
 package org.mskcc.cbio.portal.servlet;
 
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.methods.GetMethod;
-import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
-import org.mskcc.cbio.portal.repository.MutationRepositoryLegacy;
-import org.mskcc.cbio.portal.dao.*;
-import org.mskcc.cbio.portal.model.*;
-import org.mskcc.cbio.portal.util.AccessControl;
-import org.mskcc.cbio.portal.web_api.ConnectionManager;
-import org.mskcc.cbio.portal.web_api.ProtocolException;
 import org.mskcc.cbio.portal.util.*;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.context.support.SpringBeanAutowiringSupport;
 
-import java.net.URL;
-import java.util.*;
 import javax.servlet.*;
 
 /**
@@ -78,60 +51,24 @@ import javax.servlet.*;
  * @author jj
  */
 public class PatientView extends HttpServlet {
-    private static Logger logger = Logger.getLogger(PatientView.class);
-    public static final String ERROR = "user_error_message";
-    public static final String VIEW_TYPE = "view_type";
     public static final String SAMPLE_ID = "sample_id";
     public static final String PATIENT_ID = "case_id";
-    public static final String PATIENT_ID_ATTR_NAME = "PATIENT_ID";
-    public static final String PATIENT_CASE_OBJ = "case_obj";
-    public static final String CANCER_STUDY = "cancer_study";
-    public static final String HAS_SEGMENT_DATA = "has_segment_data";
     public static final String HAS_ALLELE_FREQUENCY_DATA = "has_allele_frequency_data";
     public static final String MUTATION_PROFILE = "mutation_profile";
-    public static final String CANCER_STUDY_META_DATA_KEY_STRING = "cancer_study_meta_data";
     public static final String CNA_PROFILE = "cna_profile";
     public static final String MRNA_PROFILE = "mrna_profile";
-    public static final String NUM_CASES_IN_SAME_STUDY = "num_cases";
-    public static final String NUM_CASES_IN_SAME_MUTATION_PROFILE = "num_cases_mut";
-    public static final String NUM_CASES_IN_SAME_CNA_PROFILE = "num_cases_cna";
-    public static final String NUM_CASES_IN_SAME_MRNA_PROFILE = "num_cases_mrna";
-    public static final String PATIENT_INFO = "patient_info";
-    public static final String DISEASE_INFO = "disease_info";
-    public static final String PATIENT_STATUS = "patient_status";
-    public static final String CLINICAL_DATA = "clinical_data";
-    public static final String CLINICAL_ATTRIBUTES = "clinical_attributes";
-    public static final String TISSUE_IMAGES = "tissue_images";
-    public static final String PATH_REPORT_URL = "path_report_url";
-    public static final String CLINICAL_ATTRIBUTE_OTHER_PAPTEINT_ID = "OTHER_PATIENT_ID";
-    public static final String CLINICAL_ATTRIBUTE_OTHER_SAMPLE_ID = "OTHER_SAMPLE_ID";
-    
+
     public static final String DRUG_TYPE = "drug_type";
     public static final String DRUG_TYPE_CANCER_DRUG = "cancer_drug";
     public static final String DRUG_TYPE_FDA_ONLY = "fda_approved";
-    
-    // class which process access control to cancer studies
-    private AccessControl accessControl;
 
-    @Autowired
-    private MutationRepositoryLegacy mutationRepositoryLegacy;
+    private static Logger logger = Logger.getLogger(PatientView.class);
 
     @Override
     public void init(ServletConfig config) throws ServletException {
         super.init(config);
         SpringBeanAutowiringSupport.processInjectionBasedOnServletContext(this,
                 config.getServletContext());
-    }
-
-    /**
-     * Initializes the servlet.
-     *
-     * @throws ServletException Serlvet Init Error.
-     */
-    @Override
-    public void init() throws ServletException {
-        super.init();
-        accessControl = SpringUtil.getAccessControl();
     }
     
     /** 
@@ -146,443 +83,22 @@ public class PatientView extends HttpServlet {
         XDebug xdebug = new XDebug( request );
         request.setAttribute(QueryBuilder.XDEBUG_OBJECT, xdebug);
         
-        String cancerStudyId = request.getParameter(QueryBuilder.CANCER_STUDY_ID);
-        request.setAttribute(QueryBuilder.CANCER_STUDY_ID, cancerStudyId);
-        
-        try {
-            if (validate(request)) {
-                setGeneticProfiles(request);
-                setClinicalInfo(request);
-                setNumCases(request);
-                setCancerStudyMetaData(request);
-            }
-            
-            if (request.getAttribute(ERROR)!=null) {
-                String msg = (String)request.getAttribute(ERROR);
-                xdebug.logMsg(this, msg);
-                forwardToErrorPage(request, response, msg, xdebug);
-            } else {
-                RequestDispatcher dispatcher =
-                        getServletContext().getRequestDispatcher("/WEB-INF/jsp/patient_view/patient_view.jsp");
-                dispatcher.forward(request, response);
-            }
-        
-        } catch (DaoException e) {
-            e.printStackTrace();
-            xdebug.logMsg(this, "Got Database Exception:  " + e.getMessage());
-            forwardToErrorPage(request, response,
-                    "An error occurred while trying to connect to the database.", xdebug);
-        } catch (ProtocolException e) {
-            e.printStackTrace();
-            xdebug.logMsg(this, "Got Protocol Exception " + e.getMessage());
-            forwardToErrorPage(request, response,
-                    "An error occurred while trying to authenticate.", xdebug);
-        }
-    }
-
-    /**
-     *
-     * Tests whether there is allele frequency data for a patient in a cancer study.
-     * It gets all the mutations and then checks the values for allele frequency.
-     *
-     * If mutationProfile is null then returns false
-     *
-     * @return Boolean
-     *
-     * @author Gideon Dresdner
-     */
-    public boolean hasAlleleFrequencyData(int sampleId, GeneticProfile mutationProfile) throws DaoException {
-
-        if (mutationProfile == null) {
-            // fail quietly
-            return false;
-        }
-
-        return mutationRepositoryLegacy.hasAlleleFrequencyData(mutationProfile.getGeneticProfileId(), sampleId);
-    }
-
-    private boolean validate(HttpServletRequest request) throws DaoException {
-        
-        // by default; in case return false;
-        request.setAttribute(HAS_SEGMENT_DATA, Boolean.FALSE);
-        request.setAttribute(HAS_ALLELE_FREQUENCY_DATA, Boolean.FALSE);
-        
-        String sampleIdsStr = request.getParameter(SAMPLE_ID);
-        String patientIdsStr = request.getParameter(PATIENT_ID);
-        if ((sampleIdsStr == null || sampleIdsStr.isEmpty())
-                && (patientIdsStr == null || patientIdsStr.isEmpty())) {
-            request.setAttribute(ERROR, "Please specify at least one case ID or patient ID. ");
-            return false;
-        }
-        
-        String cancerStudyId = (String) request.getAttribute(QueryBuilder.CANCER_STUDY_ID);
-        if (cancerStudyId==null) {
-            request.setAttribute(ERROR, "Please specify cancer study ID. ");
-            return false;
-        }
-        
-        CancerStudy cancerStudy = DaoCancerStudy.getCancerStudyByStableId(cancerStudyId);
-        if (cancerStudy==null) {
-            request.setAttribute(ERROR, "We have no information about cancer study "+cancerStudyId);
-            return false;
-        }
-
-        Set<Sample> samples = new HashSet<Sample>();
-        Set<String> sampleIdSet = new HashSet<String>();
-        if (sampleIdsStr!=null) {
-            for (String sampleId : sampleIdsStr.split(" +")) {
-                Sample _sample = DaoSample.getSampleByCancerStudyAndSampleId(cancerStudy.getInternalId(), sampleId);
-                if (_sample == null) {
-                    List<Sample> ss = DaoClinicalData.getSamplesByAttribute(cancerStudy.getInternalId(), CLINICAL_ATTRIBUTE_OTHER_SAMPLE_ID, sampleId);
-                    if (!ss.isEmpty()) { //TODO: what if there are more than 1 samples with the same other id
-                        _sample = ss.get(0);
-                    }
-                }
-                if (_sample != null) {
-                    samples.add(_sample);
-                    sampleIdSet.add(_sample.getStableId());
-                }
-            }
-        }
-        
-        request.setAttribute(VIEW_TYPE, "sample");
-        if (patientIdsStr!=null) {
-            request.setAttribute(VIEW_TYPE, "patient");
-            for (String patientId : patientIdsStr.split(" +")) {
-                Patient patient = DaoPatient.getPatientByCancerStudyAndPatientId(cancerStudy.getInternalId(), patientId);
-                if (patient == null) {
-                    List<Patient> ps = DaoClinicalData.getPatientsByAttribute(cancerStudy.getInternalId(), CLINICAL_ATTRIBUTE_OTHER_PAPTEINT_ID, patientId);
-                    if (!ps.isEmpty()) { //TODO: what if there are more than 1 patients with the same other id
-                        patient = ps.get(0);
-                    }
-                }
-                
-                if (patient != null) {
-                    for (Sample sample : DaoSample.getSamplesByPatientId(patient.getInternalId())) {
-                        if (sample != null) {
-                            samples.add(sample);
-                            sampleIdSet.add(sample.getStableId());
-                        }
-                    }
-                }
-            }
-        }
-
-        if (samples.isEmpty()) {
-            request.setAttribute(ERROR, "We have no information about the patient.");
-            return false;
-        }
-        
-
-        int patientId = samples.iterator().next().getInternalPatientId();
-        
-        List<String> sampleIds = new ArrayList<String>(sampleIdSet);
-        sortSampleIds(cancerStudy.getInternalId(), patientId, sampleIds);
-        
-        request.setAttribute(SAMPLE_ID, sampleIds);
-        
-        request.setAttribute(QueryBuilder.HTML_TITLE, "Patient: "+StringUtils.join(sampleIds,","));
-        
-        String cancerStudyIdentifier = cancerStudy.getCancerStudyStableId();
-
-        if (accessControl.isAccessibleCancerStudy(cancerStudyIdentifier).size() != 1) {
-            request.setAttribute(ERROR,
-                    "You are not authorized to view the cancer study with id: '" +
-                    cancerStudyIdentifier + "'. ");
-            return false;
-        }
-        else {
-            UserDetails ud = accessControl.getUserDetails();
-            if (ud != null) {
-                logger.info("PatientView.validate: Query initiated by user: " + ud.getUsername());
-            }
-        }
-        
-        request.setAttribute(PATIENT_CASE_OBJ, samples);
-        request.setAttribute(CANCER_STUDY, cancerStudy);
-
-        request.setAttribute(HAS_SEGMENT_DATA, DaoCopyNumberSegment
-                .segmentDataExistForCancerStudy(cancerStudy.getInternalId()));
-        String firstSampleId = sampleIds.get(0); 
-        Sample firstSample = DaoSample.getSampleByCancerStudyAndSampleId(cancerStudy.getInternalId(), firstSampleId);
-        request.setAttribute(HAS_ALLELE_FREQUENCY_DATA, 
-                hasAlleleFrequencyData(firstSample.getInternalId(), cancerStudy.getMutationProfile(firstSampleId)));
-        
-        return true;
-    }
-
-    private void sortSampleIds(int cancerStudyId, int patientId, List<String> sampleIds) {
-        if (sampleIds.size()==1) {
-            return;
-        }
-        try {
-            Collections.sort(sampleIds, new NaturalOrderComparator());
-
-            if (DaoClinicalEvent.timeEventsExistForPatient(patientId)) {
-                List<ClinicalEvent> events = DaoClinicalEvent.getClinicalEvent(patientId, "SPECIMEN");
-                if (events!=null) {
-                    final Map<String, Long> sampleTimes = new HashMap<String, Long>();
-                    // TODO: event data should only use SAMPLE_ID, this allows
-                    // all variations currently in the db while transitioning
-                    String[] sampleIdsInEventData = {"SpecimenReferenceNumber",
-                                                     "SPECIMEN_REFERENCE_NUMBER",
-                                                     "SAMPLE_ID"};
-                    for (ClinicalEvent event : events) {
-                        String specRefNum = null;
-                        for (String s: sampleIdsInEventData) {
-                            specRefNum = event.getEventData().get(s);
-                            if (specRefNum != null) {
-                                break;
-                            }
-                        }
-                        sampleTimes.put(specRefNum, event.getStartDate());
-                    }
-
-                    Collections.sort(sampleIds, new Comparator<String>() {
-                    @Override
-                    public int compare(String s1, String s2) {
-                        Long l1 = sampleTimes.get(s1);
-                        if (l1==null) l1 = Long.MAX_VALUE;
-                        Long l2 = sampleTimes.get(s2);
-                        if (l2==null) l2 = Long.MAX_VALUE;
-
-                        return l1.compareTo(l2);
-                    }
-                });
-                }
-            }
-
-            ClinicalAttribute attr = DaoClinicalAttributeMeta.getDatum("SAMPLE_TYPE", cancerStudyId);
-            if (attr!=null) {
-                
-                List<ClinicalData> data = DaoClinicalData.getSampleData(cancerStudyId, sampleIds, attr);
-                if (!data.isEmpty()) {
-                    final Map<String, String> sampleTypes = new HashMap<String, String>();
-                    for (ClinicalData datum : data) {
-                        sampleTypes.put(datum.getStableId(), datum.getAttrVal().toLowerCase());
-                    }
-                    Collections.sort(sampleIds, new Comparator<String>() {
-                        @Override
-                        public int compare(String s1, String s2) {
-                            int t1 = getOrderOfType(sampleTypes.get(s1));
-                            int t2 = getOrderOfType(sampleTypes.get(s2));
-                            return t1 - t2;
-                        }
-                    });
-                }
-            }
-            
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
-    
-    private int getOrderOfType(String sampleType) {
-        switch (sampleType) {
-            case "primary": return 1;
-            case "progressed": return 3;
-            case "metastasis": return 4;
-            default: return 2; // null is primary
-        }
-    }
-    
-    private void setGeneticProfiles(HttpServletRequest request) throws DaoException {
-        CancerStudy cancerStudy = (CancerStudy)request.getAttribute(CANCER_STUDY);
-        GeneticProfile mutProfile = cancerStudy.getMutationProfile();
-        if (mutProfile!=null) {
-            request.setAttribute(MUTATION_PROFILE, mutProfile);
-            request.setAttribute(NUM_CASES_IN_SAME_MUTATION_PROFILE, 
-                    DaoSampleProfile.countSamplesInProfile(mutProfile.getGeneticProfileId()));
-        }
-        
-        GeneticProfile cnaProfile = cancerStudy.getCopyNumberAlterationProfile(true);
-        if (cnaProfile!=null) {
-            request.setAttribute(CNA_PROFILE, cnaProfile);
-            request.setAttribute(NUM_CASES_IN_SAME_CNA_PROFILE, 
-                    DaoSampleProfile.countSamplesInProfile(cnaProfile.getGeneticProfileId()));
-        }
-        
-        GeneticProfile mrnaProfile = cancerStudy.getMRnaZscoresProfile();
-        if (mrnaProfile!=null) {
-            request.setAttribute(MRNA_PROFILE, mrnaProfile);
-            request.setAttribute(NUM_CASES_IN_SAME_MRNA_PROFILE, 
-                    DaoSampleProfile.countSamplesInProfile(mrnaProfile.getGeneticProfileId()));
-        }
-    }
-
-    private void setCancerStudyMetaData(HttpServletRequest request) throws DaoException, ProtocolException {
-        request.setAttribute(CANCER_STUDY_META_DATA_KEY_STRING, DaoSampleProfile.metaData(accessControl.getCancerStudies()));
-    }
-    
-    private void setNumCases(HttpServletRequest request) throws DaoException {
-        CancerStudy cancerStudy = (CancerStudy)request.getAttribute(CANCER_STUDY);
-        request.setAttribute(NUM_CASES_IN_SAME_STUDY,DaoPatient.getPatientsByCancerStudyId(cancerStudy.getInternalId()).size());
-    }
-    
-    private void setClinicalInfo(HttpServletRequest request) throws DaoException {
-        List<String> samples = (List<String>)request.getAttribute(SAMPLE_ID);
-	boolean isPatientView = request.getAttribute(VIEW_TYPE) == "patient";
-        
-        CancerStudy cancerStudy = (CancerStudy)request.getAttribute(CANCER_STUDY);
-        int cancerStudyId = cancerStudy.getInternalId();
-        List<ClinicalData> cds = DaoClinicalData.getSampleData(cancerStudyId, samples);
-        Map<String,Map<String,String>> clinicalData = new LinkedHashMap<String,Map<String,String>>();
-        for (ClinicalData cd : cds) {
-            String caseId = cd.getStableId();
-            String attrId = cd.getAttrId();
-            String attrValue = cd.getAttrVal();
-            Map<String,String> attrMap = clinicalData.get(caseId);
-            if (attrMap==null) {
-                attrMap = new HashMap<String,String>();
-                clinicalData.put(caseId, attrMap);
-            }
-            attrMap.put(attrId, attrValue);
-        }
-        request.setAttribute(CLINICAL_DATA, clinicalData);
-	
-	// Add attribute name to display name mapping
-	List<ClinicalAttribute> cas = DaoClinicalAttributeMeta.getDataByStudy(cancerStudyId);
-        
-        String sampleId = samples.get(0);
-	Map<String,Map<String,String>> clinicalAttributes = new LinkedHashMap<String,Map<String,String>>();
-        for (ClinicalAttribute ca : cas) {
-            String attrId = ca.getAttrId();
-	    String displayName = ca.getDisplayName();
-	    String description = ca.getDescription();
-            Map<String,String> attrMap = new HashMap<String,String>();
-	    clinicalAttributes.put(attrId, attrMap);
-	    attrMap.put("displayName", displayName);
-	    attrMap.put("description", description);
-        }
-	request.setAttribute(CLINICAL_ATTRIBUTES, clinicalAttributes);
-        
-        request.setAttribute("num_tumors", 1);
-        
-        // other cases with the same patient id
-        Patient patient = DaoPatient.getPatientById(DaoSample.getSampleByCancerStudyAndSampleId(cancerStudyId, sampleId).getInternalPatientId());
-        String patientId = patient.getStableId();
-        
-        // Add patient info to request
-	List<ClinicalData> patientData = DaoClinicalData.getDataByPatientId(cancerStudyId, patientId);
-	Map<String,String> patientMap = new HashMap<String,String>();
-	for (ClinicalData cd: patientData) {
-	    patientMap.put(cd.getAttrId(), cd.getAttrVal());
-	}
-	request.setAttribute(PATIENT_INFO, patientMap);
-
-        int numOfSamplesInPatient = DaoSample.getSamplesByPatientId(patient.getInternalId()).size();
-        request.setAttribute("num_tumors", numOfSamplesInPatient);
-        
-        if (numOfSamplesInPatient>1) {
-            request.setAttribute(PATIENT_ID_ATTR_NAME, patientId);
-        }
-        
-        request.setAttribute("has_timeline_data", Boolean.FALSE);
-        if (patientId!=null) {
-            request.setAttribute("has_timeline_data", DaoClinicalEvent.timeEventsExistForPatient(patient.getInternalId()));
-        }
-
-        request.setAttribute(PATIENT_ID, patientId);
-        
-        // images
-        String tisImageUrl = getTissueImageIframeUrl(cancerStudy.getCancerStudyStableId(), samples.size()>1?patientId:sampleId);
-        if (tisImageUrl!=null) {
-            request.setAttribute(TISSUE_IMAGES, tisImageUrl);
-        }
-        
-        // path report
-        String typeOfCancer = cancerStudy.getTypeOfCancerId();
-        if (patientId!=null && patientId.startsWith("TCGA-")) {
-            String pathReport = getTCGAPathReport(patientId);
-            if (pathReport!=null) {
-                request.setAttribute(PATH_REPORT_URL, pathReport);
-            }
-        }
-    }
-    
-    private String getTissueImageIframeUrl(String cancerStudyId, String caseId) {
-        if (!caseId.toUpperCase().startsWith("TCGA-")) {
-            return null;
-        }
-        
-        // test if images exist for the case
-        String metaUrl = GlobalProperties.getDigitalSlideArchiveMetaUrl(caseId);
-        
-        HttpClient client = ConnectionManager.getHttpClient(5000);
-
-        GetMethod method = new GetMethod(metaUrl);
-
-        Pattern p = Pattern.compile("<data total_count='([0-9]+)'>");
-        try {
-            int statusCode = client.executeMethod(method);
-            if (statusCode == HttpStatus.SC_OK) {
-                BufferedReader bufReader = new BufferedReader(
-                        new InputStreamReader(method.getResponseBodyAsStream()));
-                for (String line=bufReader.readLine(); line!=null; line=bufReader.readLine()) {
-                    Matcher m = p.matcher(line);
-                    if (m.find()) {
-                        int count = Integer.parseInt(m.group(1));
-                        return count>0 ? GlobalProperties.getDigitalSlideArchiveIframeUrl(caseId) : null;
-                    }
-                }
-                
-            } else {
-                //  Otherwise, throw HTTP Exception Object
-                logger.error(statusCode + ": " + HttpStatus.getStatusText(statusCode)
-                        + " Base URL:  " + metaUrl);
-            }
-        } catch (Exception ex) {
-            logger.error(ex.getMessage());
-        } finally {
-            //  Must release connection back to Apache Commons Connection Pool
-            method.releaseConnection();
-        }
-        
-        return null;
-    }
-    
-    // Map<TypeOfCancer, Map<CaseId, List<ImageName>>>
-    private static Map<String, String> pathologyReports = new HashMap<String, String>();
-    
-    private synchronized String getTCGAPathReport(String caseId) {
-        String pathologyReportUrl = pathologyReports.get(caseId);
-        if (pathologyReportUrl==null) {
-            
-            String pathReportUrl = GlobalProperties.getTCGAPathReportUrl();            
-            
-            if (pathReportUrl != null) {
-                //Strip the last item to replace it with the actual pathology report
-                String baseUrl = pathReportUrl.substring(0, pathReportUrl.lastIndexOf("/") + 1);
-                try {
-                    URL url = new URL(pathReportUrl);
-                    Scanner s = new Scanner(url.openStream());                                           
-                    
-                    // skip the first line (header)
-                    s.nextLine();
-                        for (String line=s.nextLine(); line!=null; line=s.nextLine()) {
-                            String patientId = line.split("\t")[0];
-                            String filename = line.split("\t")[1];
-                            pathologyReports.put(patientId, baseUrl + filename);
-                            }               
-                } catch (Exception ex) {
-                    logger.error(ex.getMessage());
-                }                   
-            }
-        }
-        
-        return pathologyReports.get(caseId);
-    }    
-    
-    private void forwardToErrorPage(HttpServletRequest request, HttpServletResponse response,
-                                    String userMessage, XDebug xdebug)
-            throws ServletException, IOException {
-        request.setAttribute("xdebug_object", xdebug);
-        request.setAttribute(QueryBuilder.USER_ERROR_MESSAGE, userMessage);
-        RequestDispatcher dispatcher =
-                getServletContext().getRequestDispatcher("/WEB-INF/jsp/error.jsp");
+        RequestDispatcher dispatcher = getServletContext().getRequestDispatcher("/WEB-INF/jsp/patient_view/patient_view.jsp");
         dispatcher.forward(request, response);
     }
+
+    private static String getFullURL(HttpServletRequest request) {
+        StringBuffer requestURL = request.getRequestURL();
+        String queryString = request.getQueryString();
     
+        if (queryString == null) {
+                return requestURL.toString();
+        } else {
+                return requestURL.append('?').append(queryString).toString();
+        }
+    }
+
+
     // <editor-fold defaultstate="collapsed" desc="HttpServlet methods. Click on the + sign on the left to edit the code.">
     /** 
      * Handles the HTTP <code>GET</code> method.

--- a/core/src/main/java/org/mskcc/cbio/portal/util/CheckDarwinAccessMain.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/CheckDarwinAccessMain.java
@@ -70,7 +70,7 @@ public class CheckDarwinAccessMain {
         public static String checkAccess(HttpServletRequest request) {
             if (!existsDarwinProperties()) return "";
             // if sample id does not match regex or username matches cis username then return empty string
-            String userName = GlobalProperties.getAuthenticatedUserName().split("@")[0];            
+            String userName = GlobalProperties.getAuthenticatedUserName().split("@")[0];
             String darwinResponse = "";            
             try {
                 List<String> sampleIds = (List<String>)request.getAttribute(PatientView.SAMPLE_ID);

--- a/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
+++ b/core/src/main/java/org/mskcc/cbio/portal/util/GlobalProperties.java
@@ -124,7 +124,6 @@ public class GlobalProperties {
     public static final double[] DEFAULT_GENOMIC_OVERVIEW_CNA_CUTOFF = new double[]{0.2,1.5};
     public static final String PATIENT_VIEW_DIGITAL_SLIDE_IFRAME_URL = "digitalslidearchive.iframe.url";
     public static final String PATIENT_VIEW_DIGITAL_SLIDE_META_URL = "digitalslidearchive.meta.url";
-    public static final String PATIENT_VIEW_TCGA_PATH_REPORT_URL = "tcga_path_report.url";
 
     public static final String PATIENT_VIEW_MDACC_HEATMAP_META_URL = "mdacc.heatmap.meta.url";
     public static final String PATIENT_VIEW_MDACC_HEATMAP_URL = "mdacc.heatmap.patient.url";
@@ -638,15 +637,14 @@ public class GlobalProperties {
 
     public static String getLinkToPatientView(String caseId, String cancerStudyId)
     {
-        return "case.do?" + QueryBuilder.CANCER_STUDY_ID + "=" + cancerStudyId
-                 //+ "&"+ org.mskcc.cbio.portal.servlet.PatientView.PATIENT_ID + "=" + caseId;
-                 + "&"+ org.mskcc.cbio.portal.servlet.PatientView.SAMPLE_ID + "=" + caseId;
+        return "case.do#/patient?caseId=" + caseId
+                 + "&studyId=" + cancerStudyId;
     }
 
     public static String getLinkToSampleView(String caseId, String cancerStudyId)
     {
-        return "case.do?" + QueryBuilder.CANCER_STUDY_ID + "=" + cancerStudyId
-                 + "&"+ org.mskcc.cbio.portal.servlet.PatientView.SAMPLE_ID + "=" + caseId;
+        return "case.do#/patient?sampleId=" + caseId
+                 + "&studyId=" + cancerStudyId;
     }
 
     public static String getLinkToCancerStudyView(String cancerStudyId)
@@ -702,16 +700,6 @@ public class GlobalProperties {
         String url = properties.getProperty(PATIENT_VIEW_MDACC_HEATMAP_URL);
         if (url == null || url.length() == 0) return null;
         return url + caseId;
-    }
-
-    public static String getTCGAPathReportUrl()
-    {
-        String url = GlobalProperties.getProperty(PATIENT_VIEW_TCGA_PATH_REPORT_URL);
-        if (url == null) {
-            return null;
-        }       
-        
-        return url;
     }
 
     // function for getting the custom tabs for the header

--- a/docs/Customizing-your-instance-of-cBioPortal.md
+++ b/docs/Customizing-your-instance-of-cBioPortal.md
@@ -259,6 +259,6 @@ If your documentation contains a relative link, cBioPortal will assume it uses t
 Please be aware that the links may be case-sensitive! E.g. https://github.com/cBioPortal/cbioportal/wiki/News.md is not the same as https://github.com/cBioPortal/cbioportal/wiki/news.md
 
 # Custom styling of the patient view's clinical data
-The [Patient View](http://www.cbioportal.org/case.do?cancer_study_id=lgg_ucsf_2014&case_id=P04) shows several [clinical attributes](File-Formats.md#clinical-data) at the top of the page, e.g. `AGE`, `SEX`:
+The [Patient View](http://www.cbioportal.org/case.do#/patient?studyId=lgg_ucsf_2014&caseId=P04) shows several [clinical attributes](File-Formats.md#clinical-data) at the top of the page, e.g. `AGE`, `SEX`:
 ![test](../test/end-to-end/screenshots/firefox/patient_view_lgg_ucsf_2014_case_id_P04.png)
 The order, styling and visibility of those [attributes](File-Formats.md#clinical-data) at the top can be changed by editing the [patient view's clinical attributes CSS file](../portal/src/main/webapp/css/patient-view/clinical-attributes.css).

--- a/docs/File-Formats.md
+++ b/docs/File-Formats.md
@@ -145,7 +145,7 @@ Following the metadata rows comes a tab delimited list of clinical attributes (c
 The file containing the patient attributes has one **required** column:
 - **PATIENT_ID (required)**: a unique patient ID.
 
-The following columns are used by the study view as well as the patient view. In the [study view](http://www.cbioportal.org/study?id=brca_tcga) they are used to create the survival plots. In the patient view they are used to add information to the [header](http://www.cbioportal.org/case.do?cancer_study_id=lgg_ucsf_2014&case_id=P05). 
+The following columns are used by the study view as well as the patient view. In the [study view](http://www.cbioportal.org/study?id=brca_tcga) they are used to create the survival plots. In the patient view they are used to add information to the [header](http://www.cbioportal.org/case.do#/patient?studyId=lgg_ucsf_2014&caseId=P05). 
 - **OS_STATUS**:  Overall patient survival status
     - Possible values: DECEASED, LIVING
     - In the patient view, LIVING creates a green label, DECEASED a red label.
@@ -181,7 +181,7 @@ The file containing the sample attributes has two **required** columns:
 - **PATIENT_ID (required)**: A patient ID.
 - **SAMPLE_ID (required)**: A sample ID.
 
-By adding `PATIENT_ID` here, cBioPortal will map the given sample to this patient. This enables one to associate multiple samples to one patient. For example, a single patient may have had multiple biopsies, each of which has been genomically profiled. See [this example for a patient with multiple samples](http://www.cbioportal.org/case.do?cancer_study_id=lgg_ucsf_2014&case_id=P04).
+By adding `PATIENT_ID` here, cBioPortal will map the given sample to this patient. This enables one to associate multiple samples to one patient. For example, a single patient may have had multiple biopsies, each of which has been genomically profiled. See [this example for a patient with multiple samples](http://www.cbioportal.org/case.do#/patient?studyId=lgg_ucsf_2014&caseId=P04).
 
 The following columns are required if you want the [pan-cancer summary statistics tab in a pan-cancer study](http://www.cbioportal.org/index.do?cancer_study_list=cellline_ccle_broad&cancer_study_id=cellline_ccle_broad&genetic_profile_ids_PROFILE_MUTATION_EXTENDED=cellline_ccle_broad_mutations&genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION=cellline_ccle_broad_CNA&Z_SCORE_THRESHOLD=2.0&data_priority=0&case_set_id=cellline_ccle_broad_cnaseq&case_ids=&patient_case_select=sample&gene_set_choice=prostate-cancer%3A-ar-signaling-%2810-genes%29&gene_list=SOX9+RAN+TNK2+EP300+PXN+NCOA2+AR+NRIP1+NCOR1+NCOR2&clinical_param_selection=null&tab_index=tab_visualize&Action=Submit#pancancer_study_summary):
 - **CANCER_TYPE**: Cancer Type
@@ -325,7 +325,7 @@ The log2 copy number data file follows the same format as expression data files.
 
 ## Segmented Data
 
-A SEG file (segmented data; .seg or .cbs) is a tab-delimited text file that lists loci and associated numeric values. The segmented data file format is the output of the Circular Binary Segmentation algorithm (Olshen et al., 2004).  **Segment data for import into the cBioPortal should be based on build 37 (hg19)**. This Segment data enables the 'CNA' lane in the Genomic overview of the Patient view (as [can be seen in this example](http://www.cbioportal.org/case.do?sample_id=TCGA-BH-A0E6-01&cancer_study_id=brca_tcga)). 
+A SEG file (segmented data; .seg or .cbs) is a tab-delimited text file that lists loci and associated numeric values. The segmented data file format is the output of the Circular Binary Segmentation algorithm (Olshen et al., 2004).  **Segment data for import into the cBioPortal should be based on build 37 (hg19)**. This Segment data enables the 'CNA' lane in the Genomic overview of the Patient view (as [can be seen in this example](http://www.cbioportal.org/case.do#/patient?sampleId=TCGA-BH-A0E6-01&studyId=brca_tcga)). 
 
 #### Meta file
 The segmented metadata file should contain the following fields:

--- a/docs/News.md
+++ b/docs/News.md
@@ -91,7 +91,7 @@
 # January 12, 2016
 *   **New features**:
     *   Visualization of multiple samples in a patient
-    *   Visualization of timeline data of a patient ([example](http://www.cbioportal.org/case.do?cancer_study_id=lgg_ucsf_2014&case_id=P04))<br/>
+    *   Visualization of timeline data of a patient ([example](http://www.cbioportal.org/case.do#/patient?studyId=lgg_ucsf_2014&caseId=P04))<br/>
         ![timeline-example](https://cloud.githubusercontent.com/assets/840895/12055606/cca26160-aefc-11e5-93f9-2ecfe7e95caf.png)
 *   All **TCGA data** updated to the latest Firehose run of August 21, 2015
 *   **New TCGA studies**:
@@ -321,7 +321,7 @@
 
 *   Multi-gene correlation plots.
 *   Variant allele frequency distribution plots for individual tumor samples.
-*   Tissue images for TCGA samples in the patient view, via [Digital Slide Archive](http://cancer.digitalslidearchive.net/). [Example](http://www.cbioportal.org/case.do?cancer_study_id=ucec_tcga&case_id=TCGA-BK-A0CC#tab_images).
+*   Tissue images for TCGA samples in the patient view, via [Digital Slide Archive](http://cancer.digitalslidearchive.net/). [Example](http://www.cbioportal.org/case.do#/patient?studyId=ucec_tcga&caseId=TCGA-BK-A0CC&tab=tissueImageTab).
 
 # July 16, 2013
 

--- a/portal/src/main/resources/content/examples.markdown
+++ b/portal/src/main/resources/content/examples.markdown
@@ -11,5 +11,5 @@
 <br/><br/>
 <a href="ln?q=BRAF:MUT=V600E">BRAF V600E mutations across cancer types</a>
 <br/><br/>
-<a href="case.do?cancer_study_id=ucec_tcga_pub&case_id=TCGA-BK-A0CC">Patient view of an endometrial cancer case</a>
+<a href="case.do#/patient?studyId=ucec_tcga_pub&caseId=TCGA-BK-A0CC">Patient view of an endometrial cancer case</a>
 </p>

--- a/portal/src/main/resources/content/examples_prostate.markdown
+++ b/portal/src/main/resources/content/examples_prostate.markdown
@@ -3,5 +3,5 @@
 <br/><br/>
 <a href="index.do?Action=Submit&genetic_profile_ids_PROFILE_MUTATION_EXTENDED=prad_broad_mutations&data_priority=0&case_set_id=prad_broad_sequenced&cancer_study_list=prad_broad&cancer_study_id=prad_broad&gene_list=SPOP&tab_index=tab_visualize&gene_set_choice=user-defined-list&#mutation_details">SPOP mutations in primary prostate cancer</a>
 <br/><br/>
-<a href="case.do?case_id=TCGA-CH-5788&cancer_study_id=prad_tcga">A TCGA Prostate Adenocarcinoma Case</a>
+<a href="case.do#/patient?caseId=TCGA-CH-5788&studyId=prad_tcga">A TCGA Prostate Adenocarcinoma Case</a>
 </p>

--- a/portal/src/main/resources/content/examples_tcga.markdown
+++ b/portal/src/main/resources/content/examples_tcga.markdown
@@ -13,7 +13,7 @@
 <br/><br/>
 <a href="ln?q=BRAF:MUT=V600E">BRAF V600E mutations across cancer types</a>
 <br/><br/>
-<a href="case.do?case_id=TCGA-BK-A0CC&cancer_study_id=ucec_tcga">Patient view of an endometrial cancer case</a>
+<a href="case.do#/patient?caseId=TCGA-BK-A0CC&studyId=ucec_tcga">Patient view of an endometrial cancer case</a>
 </p>
 
 

--- a/portal/src/main/resources/content/news.markdown
+++ b/portal/src/main/resources/content/news.markdown
@@ -172,7 +172,7 @@
 
 * Multi-gene correlation plots.
 * Variant allele frequency distribution plots for individual tumor samples.
-* Tissue images for TCGA samples in the patient view, via [Digital Slide Archive](http://cancer.digitalslidearchive.net/). [Example](case.do?cancer_study_id=ucec_tcga&case_id=TCGA-BK-A0CC#images).
+* Tissue images for TCGA samples in the patient view, via [Digital Slide Archive](http://cancer.digitalslidearchive.net/). [Example](case.do#/patient?studyId=ucec_tcga&caseId=TCGA-BK-A0CC&tab=tissueImageTab).
 
 # July 16, 2013
 

--- a/portal/src/main/resources/content/news_prostate.markdown
+++ b/portal/src/main/resources/content/news_prostate.markdown
@@ -42,8 +42,8 @@
 
 * Multi-gene correlation plots.
 * Variant allele frequency distribution plots for individual tumor samples.
-* Tissue images for TCGA samples in the patient view, via [Digital Slide Archive](http://cancer.digitalslidearchive.net/). [Example](case.do?cancer_study_id=prad_tcga&case_id=TCGA-CH-5788#images).
-* Support for multiple tumor samples for a single patient. [Example](case.do?cancer_study_id=prad_mich&case_id=WA43).
+* Tissue images for TCGA samples in the patient view, via [Digital Slide Archive](http://cancer.digitalslidearchive.net/). [Example](case.do#/patient?studyId=prad_tcga&caseId=TCGA-CH-5788&tab=tissueImageTab).
+* Support for multiple tumor samples for a single patient. [Example](case.do#/patient?studyId=prad_mich&caseId=WA43).
 
 # July 16, 2013
 

--- a/portal/src/main/resources/content/news_tcga.markdown
+++ b/portal/src/main/resources/content/news_tcga.markdown
@@ -82,7 +82,7 @@
 
 * Multi-gene correlation plots.
 * Variant allele frequency distribution plots for individual tumor samples.
-* Tissue images for TCGA samples in the patient view, via [Digital Slide Archive](http://cancer.digitalslidearchive.net/). [Example](case.do?cancer_study_id=ucec_tcga&case_id=TCGA-BK-A0CC#images).
+* Tissue images for TCGA samples in the patient view, via [Digital Slide Archive](http://cancer.digitalslidearchive.net/). [Example](case.do#/patient?studyId=ucec_tcga&caseId=TCGA-BK-A0CC&tab=tissueImageTab).
 
 # July 16, 2013
 

--- a/portal/src/main/webapp/WEB-INF/web.xml
+++ b/portal/src/main/webapp/WEB-INF/web.xml
@@ -456,16 +456,16 @@
         <servlet-name>MutationsJSON</servlet-name>
         <url-pattern>/mutations.json</url-pattern>
     </servlet-mapping>
-    
+
     <servlet>
-        <servlet-name>CnaJSON</servlet-name>
+    <servlet-name>CnaJSON</servlet-name>
         <servlet-class>org.mskcc.cbio.portal.servlet.CnaJSON</servlet-class>
     </servlet>
     <servlet-mapping>
         <servlet-name>CnaJSON</servlet-name>
         <url-pattern>/cna.json</url-pattern>
     </servlet-mapping>
-
+    
     <servlet>
         <servlet-name>SVGtoPDFConverter</servlet-name>
         <servlet-class>org.mskcc.cbio.portal.servlet.SvgConverter</servlet-class>

--- a/portal/src/main/webapp/WEB-INF/web.xml
+++ b/portal/src/main/webapp/WEB-INF/web.xml
@@ -449,6 +449,15 @@
     </servlet-mapping>
 
     <servlet>
+        <servlet-name>CheckDarwinAccessServlet</servlet-name>
+        <servlet-class>org.mskcc.cbio.portal.servlet.CheckDarwinAccessServlet</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>MutationsJSON</servlet-name>
+        <url-pattern>/checkDarwinAccess.do</url-pattern>
+    </servlet-mapping>
+
+    <servlet>
         <servlet-name>MutationsJSON</servlet-name>
         <servlet-class>org.mskcc.cbio.portal.servlet.MutationsJSON</servlet-class>
     </servlet>

--- a/portal/src/main/webapp/content/examples.html
+++ b/portal/src/main/webapp/content/examples.html
@@ -18,6 +18,6 @@
     <a href="ln?q=BRAF:MUT=V600E">BRAF V600E mutations across cancer types</a>
   </li>
   <li>
-    <a href="case.do?cancer_study_id=ucec_tcga_pub&case_id=TCGA-BK-A0CC">Patient view of an endometrial cancer case</a>
+    <a href="case.do#/patient?studyId=ucec_tcga_pub&caseId=TCGA-BK-A0CC">Patient view of an endometrial cancer case</a>
   </li>
 </ul>

--- a/portal/src/main/webapp/content/examples_genie.html
+++ b/portal/src/main/webapp/content/examples_genie.html
@@ -5,5 +5,5 @@
 <br/><br/>
 <a href="index.do?cancer_study_list=genie&cancer_study_id=genie&genetic_profile_ids_PROFILE_MUTATION_EXTENDED=genie_mutations&genetic_profile_ids_PROFILE_COPY_NUMBER_ALTERATION=genie_cna&data_priority=0&case_set_id=genie_cnaseq&case_ids=&patient_case_select=sample&gene_set_choice=user-defined-list&gene_list=BRAF%3A+MUT+%3D+V600&clinical_param_selection=null&tab_index=tab_visualize&Action=Submit&show_samples=false#pancancer_study_summary">BRAF V600 mutations across cancer types</a>
 <br/><br/>
-<a href="case.do?cancer_study_id=genie&case_id=GENIE-MSK-P-0001296">Lung cancer case with post-treatment T790M EGFR mutation</a>
+<a href="case.do#/patient?studyId=genie&caseId=GENIE-MSK-P-0001296">Lung cancer case with post-treatment T790M EGFR mutation</a>
 </p>

--- a/portal/src/main/webapp/content/examples_prostate.html
+++ b/portal/src/main/webapp/content/examples_prostate.html
@@ -3,5 +3,5 @@
 <br/><br/>
 <a href="index.do?Action=Submit&genetic_profile_ids_PROFILE_MUTATION_EXTENDED=prad_broad_mutations&data_priority=0&case_set_id=prad_broad_sequenced&cancer_study_list=prad_broad&cancer_study_id=prad_broad&gene_list=SPOP&tab_index=tab_visualize&gene_set_choice=user-defined-list&#mutation_details">SPOP mutations in primary prostate cancer</a>
 <br/><br/>
-<a href="case.do?case_id=TCGA-CH-5788&cancer_study_id=prad_tcga">A TCGA Prostate Adenocarcinoma Case</a>
+<a href="case.do#/patient?caseId=TCGA-CH-5788&studyId=prad_tcga">A TCGA Prostate Adenocarcinoma Case</a>
 </p>

--- a/portal/src/main/webapp/content/examples_tcga.html
+++ b/portal/src/main/webapp/content/examples_tcga.html
@@ -13,5 +13,5 @@
 <br/><br/>
 <a href="ln?q=BRAF:MUT=V600E">BRAF V600E mutations across cancer types</a>
 <br/><br/>
-<a href="case.do?case_id=TCGA-BK-A0CC&cancer_study_id=ucec_tcga">Patient view of an endometrial cancer case</a>
+<a href="case.do#/patient?caseId=TCGA-BK-A0CC&studyId=ucec_tcga">Patient view of an endometrial cancer case</a>
 </p>

--- a/portal/src/main/webapp/content/news.html
+++ b/portal/src/main/webapp/content/news.html
@@ -221,7 +221,7 @@
 <ul>
 <li>Multi-gene correlation plots.</li>
 <li>Variant allele frequency distribution plots for individual tumor samples.</li>
-<li>Tissue images for TCGA samples in the patient view, via <a href="http://cancer.digitalslidearchive.net/">Digital Slide Archive</a>. <a href="case.do?cancer_study_id=ucec_tcga&amp;case_id=TCGA-BK-A0CC#images">Example</a>.</li>
+<li>Tissue images for TCGA samples in the patient view, via <a href="http://cancer.digitalslidearchive.net/">Digital Slide Archive</a>. <a href="case.do#/patient?studyId=ucec_tcga&amp;caseId=TCGA-BK-A0CC&tab=tissueImageTab">Example</a>.</li>
 </ul>
 <h1 id="july-16-2013">July 16, 2013</h1>
 <ul>

--- a/portal/src/main/webapp/content/news_prostate.html
+++ b/portal/src/main/webapp/content/news_prostate.html
@@ -52,8 +52,8 @@
 <ul>
 <li>Multi-gene correlation plots.</li>
 <li>Variant allele frequency distribution plots for individual tumor samples.</li>
-<li>Tissue images for TCGA samples in the patient view, via <a href="http://cancer.digitalslidearchive.net/">Digital Slide Archive</a>. <a href="case.do?cancer_study_id=prad_tcga&amp;case_id=TCGA-CH-5788#images">Example</a>.</li>
-<li>Support for multiple tumor samples for a single patient. <a href="case.do?cancer_study_id=prad_mich&amp;case_id=WA43">Example</a>.</li>
+<li>Tissue images for TCGA samples in the patient view, via <a href="http://cancer.digitalslidearchive.net/">Digital Slide Archive</a>. <a href="case.do#/patient/studyId=prad_tcga&amp;caseId=TCGA-CH-5788&tab=tissueImageTab">Example</a>.</li>
+<li>Support for multiple tumor samples for a single patient. <a href="case.do#/patient/studyId=prad_mich&amp;caseId=WA43">Example</a>.</li>
 </ul>
 <h1 id="july-16-2013">July 16, 2013</h1>
 <ul>

--- a/portal/src/main/webapp/content/news_tcga.html
+++ b/portal/src/main/webapp/content/news_tcga.html
@@ -105,7 +105,7 @@
 <ul>
 <li>Multi-gene correlation plots.</li>
 <li>Variant allele frequency distribution plots for individual tumor samples.</li>
-<li>Tissue images for TCGA samples in the patient view, via <a href="http://cancer.digitalslidearchive.net/">Digital Slide Archive</a>. <a href="case.do?cancer_study_id=ucec_tcga&amp;case_id=TCGA-BK-A0CC#images">Example</a>.</li>
+<li>Tissue images for TCGA samples in the patient view, via <a href="http://cancer.digitalslidearchive.net/">Digital Slide Archive</a>. <a href="case.do#/patient?studyId=ucec_tcga&amp;caseId=TCGA-BK-A0CC&tab=tissueImageTab">Example</a>.</li>
 </ul>
 <h1 id="july-16-2013">July 16, 2013</h1>
 <ul>

--- a/portal/src/main/webapp/js/src/cbio-util.js
+++ b/portal/src/main/webapp/js/src/cbio-util.js
@@ -420,11 +420,11 @@ cbio.util = (function() {
     }
 
     function getLinkToPatientView(cancerStudyId, patientId) {
-        return "case.do?cancer_study_id=" + cancerStudyId + "&case_id=" + patientId;
+        return "case.do#/patient?studyId=" + cancerStudyId + "&caseId=" + patientId;
     }
 
     function getLinkToSampleView(cancerStudyId, sampleId) {
-        return "case.do?cancer_study_id=" + cancerStudyId + "&sample_id=" + sampleId;
+        return "case.do#/patient?studyId=" + cancerStudyId + "&sampleId=" + sampleId;
     }
 
     /**

--- a/portal/src/main/webapp/js/src/dashboard/cbio-vendor.js
+++ b/portal/src/main/webapp/js/src/dashboard/cbio-vendor.js
@@ -423,11 +423,11 @@ cbio.util = (function() {
   }
 
   function getLinkToPatientView(cancerStudyId, patientId) {
-    return "case.do?cancer_study_id=" + cancerStudyId + "&case_id=" + patientId;
+    return "case.do#/patient?studyId=" + cancerStudyId + "&caseId=" + patientId;
   }
 
   function getLinkToSampleView(cancerStudyId, sampleId) {
-    return "case.do?cancer_study_id=" + cancerStudyId + "&sample_id=" + sampleId;
+    return "case.do#/patient?studyId=" + cancerStudyId + "&sampleId=" + sampleId;
   }
 
   /**

--- a/portal/src/main/webapp/js/src/dashboard/iviz.js
+++ b/portal/src/main/webapp/js/src/dashboard/iviz.js
@@ -997,10 +997,10 @@ var iViz = (function(_, $, cbio, QueryByGeneUtil, QueryByGeneTextArea) {
       });
       if (possible) {
         var _selectedCaseIds = selectedCases_.sort();
-        var _url = window.cbioURL + 'case.do?cancer_study_id=' +
-          studyId + '&' + (type === 'patient' ? 'case_id' : 'sample_id') +
+        var _url = window.cbioURL + 'case.do#/patient?studyId=' +
+          studyId + '&' + (type === 'patient' ? 'caseId' : 'sampleId') +
           '=' + _selectedCaseIds[0] +
-          '#nav_case_ids=' + _selectedCaseIds.join(',');
+          '&navCaseIds=' + _selectedCaseIds.join(',');
         window.open(_url);
       } else {
         new Notification().createNotification(

--- a/test/end-to-end/screenshots.yml
+++ b/test/end-to-end/screenshots.yml
@@ -6,7 +6,7 @@ screenshot:
     - patient_view_lgg_ucsf_2014_case_id_P04
     - study_view_lgg_ucsf_2014
   urls:
-    - case.do?cancer_study_id=lgg_ucsf_2014&case_id=P04
+    - case.do#/patient?studyId=lgg_ucsf_2014&caseId=P04
     - study.do?cancer_study_id=lgg_ucsf_2014
   # timeout in seconds
   timeout:


### PR DESCRIPTION
Change patientview URLs to frontend routing with #

This changes all URLs with case.do to use new frontend routing with #. Also
remove all unnecessary variables and methods from `PatientView.java`. Some
other services such as the mutations.json and cna.json use the same URL
parameters so not all constants could be removed.

Remaining issues:
- Darwin service does not work anymore. The server side can't read whatever is
  after # so we'll have to make this a service instead. (Started with a draft servlet of this, but not working yet)
- All error handling related to samples or studies missing should now be on the
  frontend and is still unimplemented.

