### PR TITLE
Fix jsp in a few portal pages

### DIFF
--- a/portal/src/main/webapp/WEB-INF/jsp/global/server_vars.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/global/server_vars.jsp
@@ -1,4 +1,5 @@
 <%@ page import="org.mskcc.cbio.portal.servlet.ServletXssUtil" %>
+<%@ page import="org.mskcc.cbio.portal.util.XssRequestWrapper" %>
 <%@ page import="java.util.HashSet" %>
 <%@ page import="org.mskcc.cbio.portal.servlet.QueryBuilder" %>
 <%@ page import="org.apache.commons.lang.StringUtils" %>

--- a/portal/src/main/webapp/WEB-INF/jsp/index.jsp
+++ b/portal/src/main/webapp/WEB-INF/jsp/index.jsp
@@ -36,9 +36,6 @@
 <%@ page import="java.net.URLEncoder" %>
 <%@taglib prefix="t" tagdir="/WEB-INF/tags" %>
 
-<%@include file="global/server_vars.jsp" %>
-    
-
 <%
     String siteTitle = GlobalProperties.getTitle();
 
@@ -62,6 +59,7 @@
 <t:template title="<%=siteTitle%>" cssClass="homePage" defaultRightColumn="true" twoColumn="true" fixedWidth="false">
 
     <jsp:attribute name="head_area">
+        <jsp:include page="global/server_vars.jsp"/>
         <script>
             window.selectedCancerStudyId = '${selectedCancerStudyId}';
             if (window.selectedCancerStudyId === "all") {

--- a/portal/src/main/webapp/about_us.jsp
+++ b/portal/src/main/webapp/about_us.jsp
@@ -32,18 +32,10 @@
     
 <%@ page import="org.mskcc.cbio.portal.servlet.QueryBuilder" %>
 <%@ page import="org.mskcc.cbio.portal.util.GlobalProperties" %>
-
-<!-- js files: -->
-<script type="text/javascript" src="js/lib/jquery.min.js?<%=GlobalProperties.getAppVersion()%>"></script>
-<script type="text/javascript" src="js/lib/underscore-min.js?<%=GlobalProperties.getAppVersion()%>"></script>
-<script type="text/javascript" src="js/lib/backbone-min.js?<%=GlobalProperties.getAppVersion()%>"></script>
-
-<script type="text/javascript" src="js/lib/showdown.min.js?<%=GlobalProperties.getAppVersion()%>"></script>
-<script type="text/javascript" src="js/lib/showdown-github.min.js?<%=GlobalProperties.getAppVersion()%>"></script>
-<script type="text/javascript" src="js/src/url_based_content.js?<%=GlobalProperties.getAppVersion()%>"></script>
     
 <%
     String siteTitle = GlobalProperties.getTitle() + "::About Us";
+    String appVersion = GlobalProperties.getAppVersion();
 %>
 
 <%@taglib prefix="t" tagdir="/WEB-INF/tags" %>
@@ -51,6 +43,15 @@
 <t:template title="<%= siteTitle %>" defaultRightColumn="true" fixedWidth="true">
 
     <jsp:attribute name="head_area">
+        
+        <!-- js files: -->
+        <script type="text/javascript" src="js/lib/jquery.min.js?${appVersion}"></script>
+        <script type="text/javascript" src="js/lib/underscore-min.js?${appVersion}"></script>
+        <script type="text/javascript" src="js/lib/backbone-min.js?${appVersion}"></script>
+
+        <script type="text/javascript" src="js/lib/showdown.min.js?${appVersion}"></script>
+        <script type="text/javascript" src="js/lib/showdown-github.min.js?${appVersion}"></script>
+        <script type="text/javascript" src="js/src/url_based_content.js?${appVersion}"></script>
         <script>
         window.loadReactApp({ defaultRoute: 'blank' });
         </script>

--- a/portal/src/main/webapp/faq.jsp
+++ b/portal/src/main/webapp/faq.jsp
@@ -32,18 +32,10 @@
 
 <%@ page import="org.mskcc.cbio.portal.servlet.QueryBuilder" %>
 <%@ page import="org.mskcc.cbio.portal.util.GlobalProperties" %>
-
-<!-- js files: -->
-<script type="text/javascript" src="js/lib/jquery.min.js?<%=GlobalProperties.getAppVersion()%>"></script>
-<script type="text/javascript" src="js/lib/underscore-min.js?<%=GlobalProperties.getAppVersion()%>"></script>
-<script type="text/javascript" src="js/lib/backbone-min.js?<%=GlobalProperties.getAppVersion()%>"></script>
-
-<script type="text/javascript" src="js/lib/showdown.min.js?<%=GlobalProperties.getAppVersion()%>"></script>
-<script type="text/javascript" src="js/lib/showdown-github.min.js?<%=GlobalProperties.getAppVersion()%>"></script>
-<script type="text/javascript" src="js/src/url_based_content.js?<%=GlobalProperties.getAppVersion()%>"></script>
-    
+  
 <%
     String siteTitle = GlobalProperties.getTitle() + "::FAQ";
+    String appVersion = GlobalProperties.getAppVersion();
 %>
 
 <%@taglib prefix="t" tagdir="/WEB-INF/tags" %>
@@ -51,6 +43,14 @@
 <t:template title="<%= siteTitle %>" defaultRightColumn="true" fixedWidth="true">
 
     <jsp:attribute name="head_area">
+        <!-- js files: -->
+        <script type="text/javascript" src="js/lib/jquery.min.js?${appVersion}"></script>
+        <script type="text/javascript" src="js/lib/underscore-min.js?${appVersion}"></script>
+        <script type="text/javascript" src="js/lib/backbone-min.js?${appVersion}"></script>
+
+        <script type="text/javascript" src="js/lib/showdown.min.js?${appVersion}"></script>
+        <script type="text/javascript" src="js/lib/showdown-github.min.js?${appVersion}"></script>
+        <script type="text/javascript" src="js/src/url_based_content.js?${appVersion}"></script>
         <script>
         window.loadReactApp({ defaultRoute: 'blank' });
         </script>

--- a/portal/src/main/webapp/news.jsp
+++ b/portal/src/main/webapp/news.jsp
@@ -33,18 +33,10 @@
 
 <%@ page import="org.mskcc.cbio.portal.servlet.QueryBuilder" %>
 <%@ page import="org.mskcc.cbio.portal.util.GlobalProperties" %>
-
-<!-- js files: -->
-<script type="text/javascript" src="js/lib/jquery.min.js?<%=GlobalProperties.getAppVersion()%>"></script>
-<script type="text/javascript" src="js/lib/underscore-min.js?<%=GlobalProperties.getAppVersion()%>"></script>
-<script type="text/javascript" src="js/lib/backbone-min.js?<%=GlobalProperties.getAppVersion()%>"></script>
-
-<script type="text/javascript" src="js/lib/showdown.min.js?<%=GlobalProperties.getAppVersion()%>"></script>
-<script type="text/javascript" src="js/lib/showdown-github.min.js?<%=GlobalProperties.getAppVersion()%>"></script>
-<script type="text/javascript" src="js/src/url_based_content.js?<%=GlobalProperties.getAppVersion()%>"></script>
-        
+      
 <%
     String siteTitle = GlobalProperties.getTitle() + "::FAQ";
+    String appVersion = GlobalProperties.getAppVersion();
 %>
 
 <%@taglib prefix="t" tagdir="/WEB-INF/tags" %>
@@ -52,6 +44,14 @@
 <t:template title="<%= siteTitle %>" defaultRightColumn="false" fixedWidth="true" cssClass="newsPage">
 
     <jsp:attribute name="head_area">
+        <!-- js files: -->
+        <script type="text/javascript" src="js/lib/jquery.min.js?${appVersion}"></script>
+        <script type="text/javascript" src="js/lib/underscore-min.js?${appVersion}"></script>
+        <script type="text/javascript" src="js/lib/backbone-min.js?${appVersion}"></script>
+
+        <script type="text/javascript" src="js/lib/showdown.min.js?${appVersion}"></script>
+        <script type="text/javascript" src="js/lib/showdown-github.min.js?${appVersion}"></script>
+        <script type="text/javascript" src="js/src/url_based_content.js?${appVersion}"></script>
         <script>
         window.loadReactApp({ defaultRoute: 'blank' });
         </script>


### PR DESCRIPTION
Fix About Us, FAQ, and News to be valid HTML by moving script
tags inside the header

Fix index.jsp to be valid HTML by moving server_vars.jsp include
inside the header, and add an import to server_vars.jsp to make
this work.